### PR TITLE
Set ffi_yajl version to 1.0.2, install build-essential package directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :unit do
   gem 'should_not', '~> 1.1'
   gem 'chefspec', '~> 4.1'
   gem 'chef-encrypted-attributes'
+  gem 'ohai', '~> 7.4' if RUBY_VERSION < '2'
 end
 
 group :integration do

--- a/libraries/cookbook_helpers.rb
+++ b/libraries/cookbook_helpers.rb
@@ -132,7 +132,7 @@ class EncryptedAttributesCookbook
       if chef11new? && oldgem?(gem_version)
         { 'yajl-ruby' => nil }
       elsif chef11old? && newgem?(gem_version)
-        { 'ffi-yajl' => nil }
+        { 'ffi-yajl' => '1.0.2' }
       else
         {}
       end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,7 @@ gem_options = []
 if EncryptedAttributesCookbook::Helpers.require_build_essential?(gem_version)
   include_recipe 'build-essential'
 end
+
 if EncryptedAttributesCookbook::Helpers.skip_gem_dependencies?(gem_version)
   gem_options << '--ignore-dependencies'
 end

--- a/spec/unit/cookbook_helpers_spec.rb
+++ b/spec/unit/cookbook_helpers_spec.rb
@@ -81,9 +81,12 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
       { chef_version: '12.0.0',  gem_version: '0.4.0', result: nil         },
       { chef_version: '11.16.4', gem_version: nil,     result: nil         },
       { chef_version: '11.16.4', gem_version: '0.4.0', result: nil         },
-      { chef_version: '11.16.4', gem_version: '0.3.0', result: 'yajl-ruby' },
-      { chef_version: '11.12.8', gem_version: nil,     result: 'ffi-yajl'  },
-      { chef_version: '11.12.8', gem_version: '0.4.0', result: 'ffi-yajl'  },
+      { chef_version: '11.16.4', gem_version: '0.3.0', result: 'yajl-ruby',
+        result_version: nil },
+      { chef_version: '11.12.8', gem_version: nil,     result: 'ffi-yajl',
+        result_version: '1.0.2' },
+      { chef_version: '11.12.8', gem_version: '0.4.0', result: 'ffi-yajl',
+        result_version: '1.0.2' },
       { chef_version: '11.12.8', gem_version: '0.3.0', result: nil         }
     ].each do |test|
       context "with Chef #{test[:chef_version].inspect} and gem version"\
@@ -91,7 +94,8 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
         before { stub_const('Chef::VERSION', test[:chef_version]) }
 
         it "returns #{test[:result].inspect} as dependency" do
-          result = test[:result].nil? ? {} : { test[:result] => nil }
+          result = test[:result].nil? ? {} : { test[:result] =>
+                                                   test[:result_version] }
           expect(helpers.required_depends(test[:gem_version]))
             .to eq(result)
         end


### PR DESCRIPTION
ffi-yajl now has a 2.0 version, but chef-zero and encrypted_attributes require ~> 1.0 and 1.1. 

also, I was unable to get ffi-yajl to install (complaints about dev tools not installed) despite the build-essential cookbook being pulled in. the only solution that worked for me was to explicitly include the package.