### PR TITLE
Update for 0.6.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,14 +39,36 @@ suites:
     - recipe[encrypted_attributes_test::default]
   provisioner:
     require_chef_omnibus: 11.12.8
+- name: gem050
+  run_list:
+    - recipe[encrypted_attributes_test::default]
+  attributes:
+    encrypted_attributes:
+      version: 0.5.0
+- name: gem050-chef11
+  provisioner:
+    require_chef_omnibus: 11.16.4
+  run_list:
+    - recipe[encrypted_attributes_test::default]
+  attributes:
+    encrypted_attributes:
+      version: 0.5.0
+- name: gem050-chef11old
+  provisioner:
+    require_chef_omnibus: 11.12.8
+  run_list:
+    - recipe[encrypted_attributes_test::default]
+  attributes:
+    encrypted_attributes:
+      version: 0.5.0
 # chef-encrypted-attributes 0.3.0 only works with Chef 11 due to depends
-# - name: oldgem
+# - name: gem030
 #   run_list:
 #     - recipe[encrypted_attributes_test::default]
 #   attributes:
 #     encrypted_attributes:
 #       version: 0.3.0
-- name: oldgem-chef11
+- name: gem030-chef11
   provisioner:
     require_chef_omnibus: 11.16.4
   run_list:
@@ -54,7 +76,7 @@ suites:
   attributes:
     encrypted_attributes:
       version: 0.3.0
-- name: oldgem-chef11old
+- name: gem030-chef11old
   provisioner:
     require_chef_omnibus: 11.12.8
   run_list:

--- a/libraries/cookbook_helpers.rb
+++ b/libraries/cookbook_helpers.rb
@@ -23,11 +23,13 @@
 class EncryptedAttributesCookbook
   # Some helpers used in the `encrypted_attribute` cookbook.
   module Helpers
-    # The latest chef-encrypted-attributes gem version, or at least the latest
-    # that requires different installation steps.  This is used as a default
-    # when a nil version is specified.
-    # @api private
-    LATEST = '0.6.0'
+    unless defined?(LATEST)
+      # The latest chef-encrypted-attributes gem version, or at least the latest
+      # that requires different installation steps.  This is used as a default
+      # when a nil version is specified.
+      # @api private
+      LATEST = '0.6.0'
+    end
 
     # Determines which YAJL library is already available, based on the Chef
     # version.

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -71,11 +71,14 @@ describe 'encrypted_attributes::default', order: :random do
 
   [
     { chef: '12.0.0',  gem: nil,     builds: false, depend: nil         },
+    { chef: '12.0.0',  gem: '0.6.0', builds: false, depend: nil         },
     { chef: '12.0.0',  gem: '0.4.0', builds: false, depend: nil         },
     { chef: '11.16.4', gem: nil,     builds: false, depend: nil         },
+    { chef: '11.16.4', gem: '0.6.0', builds: false, depend: nil         },
     { chef: '11.16.4', gem: '0.4.0', builds: false, depend: nil         },
     { chef: '11.16.4', gem: '0.3.0', builds: true,  depend: 'yajl-ruby' },
-    { chef: '11.12.8', gem: nil,     builds: true,  depend: 'ffi-yajl'  },
+    { chef: '11.12.8', gem: nil,     builds: false, depend: nil         },
+    { chef: '11.12.8', gem: '0.6.0', builds: false, depend: nil         },
     { chef: '11.12.8', gem: '0.4.0', builds: true,  depend: 'ffi-yajl'  },
     { chef: '11.12.8', gem: '0.3.0', builds: false, depend: nil         }
   ].each do |test|

--- a/spec/unit/cookbook_helpers_spec.rb
+++ b/spec/unit/cookbook_helpers_spec.rb
@@ -26,14 +26,18 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
   context '.require_build_essential?' do
     [
       { chef_version: '12.0.0',  gem_version: nil,     result: false },
+      { chef_version: '12.0.0',  gem_version: '0.6.0', result: false },
       { chef_version: '12.0.0',  gem_version: '0.4.0', result: false },
       { chef_version: '11.16.4', gem_version: nil,     result: false },
+      { chef_version: '11.16.4', gem_version: '0.6.0', result: false },
       { chef_version: '11.16.4', gem_version: '0.4.0', result: false },
       { chef_version: '11.16.4', gem_version: '0.3.0', result: true  },
-      { chef_version: '11.12.8', gem_version: nil,     result: true  },
+      { chef_version: '11.12.8', gem_version: nil,     result: false },
+      { chef_version: '11.12.8', gem_version: '0.6.0', result: false },
       { chef_version: '11.12.8', gem_version: '0.4.0', result: true  },
       { chef_version: '11.12.8', gem_version: '0.3.0', result: false },
       { chef_version: '11.6.0',  gem_version: nil,     result: false },
+      { chef_version: '11.6.0',  gem_version: '0.6.0', result: false },
       { chef_version: '11.6.0',  gem_version: '0.4.0', result: true  },
       { chef_version: '11.6.0',  gem_version: '0.3.0', result: false }
     ].each do |test|
@@ -58,14 +62,18 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
   context '.skip_gem_dependencies?' do
     [
       { chef_version: '12.0.0',  gem_version: nil,     result: true },
+      { chef_version: '12.0.0',  gem_version: '0.6.0', result: true },
       { chef_version: '12.0.0',  gem_version: '0.4.0', result: true },
       { chef_version: '11.16.4', gem_version: nil,     result: true },
+      { chef_version: '11.16.4', gem_version: '0.6.0', result: true },
       { chef_version: '11.16.4', gem_version: '0.4.0', result: true },
       { chef_version: '11.16.4', gem_version: '0.3.0', result: true },
       { chef_version: '11.12.8', gem_version: nil,     result: true },
+      { chef_version: '11.12.8', gem_version: '0.6.0', result: true },
       { chef_version: '11.12.8', gem_version: '0.4.0', result: true },
       { chef_version: '11.12.8', gem_version: '0.3.0', result: true },
       { chef_version: '11.6.0',  gem_version: nil,     result: true },
+      { chef_version: '11.6.0',  gem_version: '0.6.0', result: true },
       { chef_version: '11.6.0',  gem_version: '0.4.0', result: true },
       { chef_version: '11.6.0',  gem_version: '0.3.0', result: true }
     ].each do |test|
@@ -84,17 +92,20 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
   context '.required_depends' do
     [
       { chef_version: '12.0.0',  gem_version: nil,     result: nil         },
+      { chef_version: '12.0.0',  gem_version: '0.6.0', result: nil         },
       { chef_version: '12.0.0',  gem_version: '0.4.0', result: nil         },
       { chef_version: '11.16.4', gem_version: nil,     result: nil         },
+      { chef_version: '11.16.4', gem_version: '0.6.0', result: nil         },
       { chef_version: '11.16.4', gem_version: '0.4.0', result: nil         },
       { chef_version: '11.16.4', gem_version: '0.3.0', result: 'yajl-ruby',
         result_version: nil },
-      { chef_version: '11.12.8', gem_version: nil,     result: 'ffi-yajl',
-        result_version: '1.0.2' },
+      { chef_version: '11.12.8', gem_version: nil,     result: nil         },
+      { chef_version: '11.12.8', gem_version: '0.6.0', result: nil         },
       { chef_version: '11.12.8', gem_version: '0.4.0', result: 'ffi-yajl',
         result_version: '1.0.2' },
       { chef_version: '11.12.8', gem_version: '0.3.0', result: nil         },
       { chef_version: '11.6.0',  gem_version: nil,     result: nil         },
+      { chef_version: '11.6.0',  gem_version: '0.6.0', result: nil         },
       { chef_version: '11.6.0',  gem_version: '0.4.0', result: 'ffi-yajl',
         result_version: '1.0.2' },
       { chef_version: '11.6.0',  gem_version: '0.3.0', result: nil         }
@@ -126,7 +137,9 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
       '0.3.0' => false,
       '0.4.0.dev' => true,
       '0.4.0.beta.0' => true,
-      '0.4.0' => false
+      '0.4.0' => false,
+      '0.6.0.beta.2' => true,
+      '0.6.0' => false
     }.each do |version, result|
       context "with version #{version.inspect}" do
         it "returns #{result.inspect}" do

--- a/spec/unit/cookbook_helpers_spec.rb
+++ b/spec/unit/cookbook_helpers_spec.rb
@@ -32,7 +32,10 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
       { chef_version: '11.16.4', gem_version: '0.3.0', result: true  },
       { chef_version: '11.12.8', gem_version: nil,     result: true  },
       { chef_version: '11.12.8', gem_version: '0.4.0', result: true  },
-      { chef_version: '11.12.8', gem_version: '0.3.0', result: false }
+      { chef_version: '11.12.8', gem_version: '0.3.0', result: false },
+      { chef_version: '11.6.0',  gem_version: nil,     result: false },
+      { chef_version: '11.6.0',  gem_version: '0.4.0', result: true  },
+      { chef_version: '11.6.0',  gem_version: '0.3.0', result: false }
     ].each do |test|
       context "with Chef #{test[:chef_version].inspect} and gem version"\
               " #{test[:gem_version].inspect}" do
@@ -61,7 +64,10 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
       { chef_version: '11.16.4', gem_version: '0.3.0', result: true },
       { chef_version: '11.12.8', gem_version: nil,     result: true },
       { chef_version: '11.12.8', gem_version: '0.4.0', result: true },
-      { chef_version: '11.12.8', gem_version: '0.3.0', result: true }
+      { chef_version: '11.12.8', gem_version: '0.3.0', result: true },
+      { chef_version: '11.6.0',  gem_version: nil,     result: true },
+      { chef_version: '11.6.0',  gem_version: '0.4.0', result: true },
+      { chef_version: '11.6.0',  gem_version: '0.3.0', result: true }
     ].each do |test|
       context "with Chef #{test[:chef_version].inspect} and gem version"\
               " #{test[:gem_version].inspect}" do
@@ -87,7 +93,11 @@ describe EncryptedAttributesCookbook::Helpers, order: :random do
         result_version: '1.0.2' },
       { chef_version: '11.12.8', gem_version: '0.4.0', result: 'ffi-yajl',
         result_version: '1.0.2' },
-      { chef_version: '11.12.8', gem_version: '0.3.0', result: nil         }
+      { chef_version: '11.12.8', gem_version: '0.3.0', result: nil         },
+      { chef_version: '11.6.0',  gem_version: nil,     result: nil         },
+      { chef_version: '11.6.0',  gem_version: '0.4.0', result: 'ffi-yajl',
+        result_version: '1.0.2' },
+      { chef_version: '11.6.0',  gem_version: '0.3.0', result: nil         }
     ].each do |test|
       context "with Chef #{test[:chef_version].inspect} and gem version"\
               " #{test[:gem_version].inspect}" do


### PR DESCRIPTION
The first commit adds a test to catch the version bug that we discussed in https://github.com/onddo/chef-encrypted-attributes/pull/4.  I only added these cases to the unit tests because they run faster and that was sufficient to catch the bug.  Let me know if you prefer for me to add the extra cases to spec/recipes/default_spec.rb as well.

The second and third commits update the cookbook not to install any dependencies when using gem version 0.6.0 and above.  I refactored the logic that decides what to install in order to make it easier for me to make the update for 0.6.0.  My aim was to make the intent more clear, but let me know if you don't like the refactor, and I'm happy to adjust it.